### PR TITLE
Add pagination to DataTable and paginated API endpoints

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,10 +4,93 @@ import helmet from 'helmet';
 
 const app = express();
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+const perPageOptions = [10, 25, 50];
 
 app.use(helmet());
 app.use(cors());
 app.use(express.json());
+
+type PaginatedResponse<T> = {
+  data: T[];
+  meta: {
+    total: number;
+    page: number;
+    perPage: number;
+    totalPages: number;
+  };
+};
+
+const parsePage = (value: unknown) => {
+  const page = Number(value);
+  return Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+};
+
+const parsePerPage = (value: unknown) => {
+  const perPage = Number(value);
+  if (Number.isFinite(perPage) && perPageOptions.includes(perPage)) {
+    return perPage;
+  }
+  return perPageOptions[0];
+};
+
+const paginate = <T>(items: T[], page: number, perPage: number): PaginatedResponse<T> => {
+  const total = items.length;
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+  const safePage = Math.min(page, totalPages);
+  const start = (safePage - 1) * perPage;
+  return {
+    data: items.slice(start, start + perPage),
+    meta: {
+      total,
+      page: safePage,
+      perPage,
+      totalPages
+    }
+  };
+};
+
+const products = [
+  { id: 'prod-1', name: 'Beratung', price: '€ 180', unit: 'Stunde', taxRate: '19%' },
+  { id: 'prod-2', name: 'Design-Paket', price: '€ 950', unit: 'Paket', taxRate: '7%' },
+  { id: 'prod-3', name: 'Audit', price: '€ 1.200', unit: 'Paket', taxRate: '19%' },
+  { id: 'prod-4', name: 'Support', price: '€ 95', unit: 'Stunde', taxRate: '19%' }
+];
+
+const customers = [
+  { id: 'cust-1', name: 'Muster GmbH', city: 'Hamburg', status: 'Aktiv', revenue: '€ 12.500' },
+  { id: 'cust-2', name: 'Nordwind AG', city: 'Berlin', status: 'Aktiv', revenue: '€ 48.300' },
+  { id: 'cust-3', name: 'Komet KG', city: 'Leipzig', status: 'Pausiert', revenue: '€ 5.900' }
+];
+
+const users = [
+  { id: 'user-1', name: 'Lisa Weber', role: 'ORG_LEADER', email: 'lisa@example.com' },
+  { id: 'user-2', name: 'Sven Koch', role: 'MEMBER', email: 'sven@example.com' },
+  { id: 'user-3', name: 'Nina Roth', role: 'ADMIN', email: 'nina@example.com' }
+];
+
+const invoices = [
+  {
+    id: 'inv-1',
+    number: 'RE-2024-120',
+    customer: 'Muster GmbH',
+    date: '12.09.2024',
+    status: 'Offen',
+    amount: '€ 1.250'
+  },
+  {
+    id: 'inv-2',
+    number: 'GS-2024-013',
+    customer: 'Nordwind AG',
+    date: '01.09.2024',
+    status: 'Bezahlt',
+    amount: '-€ 250'
+  }
+];
+
+const organizations = [
+  { id: 'org-1', name: 'Muster GmbH', leader: 'Lisa Weber', plan: 'Free', invoices: 8 },
+  { id: 'org-2', name: 'Nordwind AG', leader: 'Sven Koch', plan: 'Paid', invoices: 32 }
+];
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', service: 'zeus-backend' });
@@ -22,6 +105,36 @@ app.get('/', (_req, res) => {
       'Role-based permissions'
     ]
   });
+});
+
+app.get('/api/products', (req, res) => {
+  const page = parsePage(req.query.page);
+  const perPage = parsePerPage(req.query.perPage);
+  res.json(paginate(products, page, perPage));
+});
+
+app.get('/api/customers', (req, res) => {
+  const page = parsePage(req.query.page);
+  const perPage = parsePerPage(req.query.perPage);
+  res.json(paginate(customers, page, perPage));
+});
+
+app.get('/api/users', (req, res) => {
+  const page = parsePage(req.query.page);
+  const perPage = parsePerPage(req.query.perPage);
+  res.json(paginate(users, page, perPage));
+});
+
+app.get('/api/invoices', (req, res) => {
+  const page = parsePage(req.query.page);
+  const perPage = parsePerPage(req.query.perPage);
+  res.json(paginate(invoices, page, perPage));
+});
+
+app.get('/api/admin/organizations', (req, res) => {
+  const page = parsePage(req.query.page);
+  const perPage = parsePerPage(req.query.perPage);
+  res.json(paginate(organizations, page, perPage));
 });
 
 app.listen(port, () => {

--- a/frontend/src/components/DataTable.vue
+++ b/frontend/src/components/DataTable.vue
@@ -14,7 +14,7 @@
       </thead>
       <tbody class="divide-y divide-slate-800 bg-slate-950">
         <tr
-          v-for="(row, index) in rows"
+          v-for="(row, index) in paginatedRows"
           :key="index"
           class="hover:bg-slate-900/60"
         >
@@ -28,12 +28,88 @@
         </tr>
       </tbody>
     </table>
+    <div class="flex flex-wrap items-center justify-between gap-3 border-t border-slate-800 bg-slate-900 px-4 py-3 text-sm text-slate-300">
+      <div class="flex items-center gap-3">
+        <span>Einträge pro Seite</span>
+        <select
+          v-model.number="pageSize"
+          class="rounded-lg border border-slate-700 bg-slate-950 px-2 py-1 text-slate-200"
+        >
+          <option v-for="option in resolvedPageSizeOptions" :key="option" :value="option">
+            {{ option }}
+          </option>
+        </select>
+      </div>
+      <div class="flex items-center gap-4">
+        <span>{{ rangeLabel }}</span>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="rounded-lg border border-slate-700 px-2 py-1 text-slate-200 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="currentPage === 1"
+            @click="currentPage--"
+          >
+            Zurück
+          </button>
+          <button
+            type="button"
+            class="rounded-lg border border-slate-700 px-2 py-1 text-slate-200 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="currentPage >= totalPages"
+            @click="currentPage++"
+          >
+            Weiter
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps<{
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps<{
   headers: string[];
   rows: string[][];
+  pageSizeOptions?: number[];
+  initialPageSize?: number;
 }>();
+
+const defaultOptions = [10, 25, 50];
+const resolvedPageSizeOptions = computed(() =>
+  props.pageSizeOptions && props.pageSizeOptions.length > 0
+    ? props.pageSizeOptions
+    : defaultOptions
+);
+const pageSize = ref(props.initialPageSize ?? resolvedPageSizeOptions.value[0]);
+const currentPage = ref(1);
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(props.rows.length / pageSize.value))
+);
+const paginatedRows = computed(() => {
+  const start = (currentPage.value - 1) * pageSize.value;
+  return props.rows.slice(start, start + pageSize.value);
+});
+const rangeLabel = computed(() => {
+  if (props.rows.length === 0) {
+    return '0 von 0';
+  }
+  const start = (currentPage.value - 1) * pageSize.value + 1;
+  const end = Math.min(currentPage.value * pageSize.value, props.rows.length);
+  return `${start}-${end} von ${props.rows.length}`;
+});
+
+watch(pageSize, () => {
+  currentPage.value = 1;
+});
+
+watch(
+  () => props.rows.length,
+  () => {
+    if (currentPage.value > totalPages.value) {
+      currentPage.value = totalPages.value;
+    }
+  }
+);
 </script>


### PR DESCRIPTION
### Motivation

- Provide client-side pagination controls for tables so large datasets can be browsed in pages.
- Expose the same pagination semantics on the backend API so frontend tables can request paged data instead of loading everything.
- Offer a per-page selector with the common options `10`, `25`, and `50` to match UX expectations.

### Description

- Frontend: enhanced `frontend/src/components/DataTable.vue` to support client-side pagination with props `pageSizeOptions` and `initialPageSize`, computed `paginatedRows`, a page-size `<select>`, previous/next buttons and a range label.
- Backend: extended `backend/src/server.ts` with `perPageOptions`, `parsePage`, `parsePerPage`, and a generic `paginate` helper, plus sample datasets and paginated endpoints at `GET /api/products`, `GET /api/customers`, `GET /api/users`, `GET /api/invoices`, and `GET /api/admin/organizations` returning `{ data, meta }`.
- The pagination enforces allowed per-page values (`10|25|50`) and normalizes pages to the valid range.

### Testing

- Attempted to install frontend dependencies with `npm install` to run the app, but the install failed due to a 403 while fetching `@headlessui/vue`, so the frontend dev server and integration checks could not be started.
- No automated server-side tests were executed; the new backend endpoints are implemented and can be exercised once the app is running or via `curl`/Postman against a running backend.
- Static inspection of modified files was performed to verify added logic and exports, and the changes were applied successfully to the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987583e27c08323b2293079c7b40070)