### PR TITLE
Connect CustomerDetailPage to backend data

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -96,6 +96,23 @@ app.get('/api/customers', async (req, res) => {
   res.json(buildPaginatedResponse(data, total, page, perPage));
 });
 
+app.get('/api/customers/:id', async (req, res) => {
+  const customer = await prisma.customer.findUnique({
+    where: { id: req.params.id },
+    include: {
+      invoices: { orderBy: { issuedAt: 'desc' } },
+      notes: { orderBy: { createdAt: 'desc' }, include: { author: true } }
+    }
+  });
+
+  if (!customer) {
+    res.status(404).json({ message: 'Customer not found' });
+    return;
+  }
+
+  res.json(customer);
+});
+
 app.get('/api/users', async (req, res) => {
   const perPage = parsePerPage(req.query.perPage);
   const requestedPage = parsePage(req.query.page);

--- a/frontend/src/components/InputField.vue
+++ b/frontend/src/components/InputField.vue
@@ -4,7 +4,9 @@
     <input
       :type="type"
       :placeholder="placeholder"
+      :value="modelValue"
       class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-slate-100"
+      @input="handleInput"
     />
   </label>
 </template>
@@ -15,10 +17,19 @@ withDefaults(
     label: string;
     type?: string;
     placeholder?: string;
+    modelValue?: string;
   }>(),
   {
     type: 'text',
-    placeholder: ''
+    placeholder: '',
+    modelValue: ''
   }
 );
+
+const emit = defineEmits<{ (event: 'update:modelValue', value: string): void }>();
+
+const handleInput = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  emit('update:modelValue', target.value);
+};
 </script>

--- a/frontend/src/pages/CustomerDetailPage.vue
+++ b/frontend/src/pages/CustomerDetailPage.vue
@@ -2,8 +2,9 @@
   <section class="space-y-8">
     <div class="flex items-center justify-between">
       <div>
-        <Headline size="lg">Kunde: Muster GmbH</Headline>
+        <Headline size="lg">Kunde: {{ customer?.name ?? 'Lädt...' }}</Headline>
         <Text tone="muted">Adresse, Ansprechpartner und Notizen verwalten.</Text>
+        <Text v-if="isLoading" tone="muted">Kundendaten werden geladen…</Text>
       </div>
       <Button variant="secondary">Speichern</Button>
     </div>
@@ -11,18 +12,32 @@
     <div class="grid gap-6 lg:grid-cols-2">
       <div class="rounded-2xl border border-slate-800 bg-slate-900 p-6 space-y-4">
         <Headline size="md">Kerndaten</Headline>
-        <InputField label="Adresse" placeholder="Hauptstraße 1, 10115 Berlin" />
-        <InputField label="Ansprechpartner" placeholder="Erika Mustermann" />
-        <InputField label="Telefon" placeholder="+49 30 123456" />
+        <InputField
+          v-model="customerForm.address"
+          label="Adresse"
+          :placeholder="customer?.address ?? 'Keine Adresse hinterlegt'"
+        />
+        <InputField
+          v-model="customerForm.contactPerson"
+          label="Ansprechpartner"
+          :placeholder="customer?.contactPerson ?? 'Kein Ansprechpartner hinterlegt'"
+        />
+        <InputField
+          v-model="customerForm.phone"
+          label="Telefon"
+          :placeholder="customer?.phone ?? 'Keine Telefonnummer hinterlegt'"
+        />
       </div>
       <div class="rounded-2xl border border-slate-800 bg-slate-900 p-6 space-y-4">
         <Headline size="md">Notizen</Headline>
-        <Text tone="muted">Letzter Eintrag von: Max Müller</Text>
+        <Text tone="muted">
+          Letzter Eintrag von: {{ latestNote?.author.displayName ?? '—' }}
+        </Text>
         <textarea
           class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
           rows="6"
-          placeholder="Notiz über den Kunden"
-        ></textarea>
+          :placeholder="latestNote?.content ?? 'Notiz über den Kunden'"
+        >{{ latestNote?.content ?? '' }}</textarea>
         <Button variant="primary">Notiz speichern</Button>
       </div>
     </div>
@@ -48,14 +63,115 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
 import Headline from '../components/Headline.vue';
 import Text from '../components/Text.vue';
 import Button from '../components/Button.vue';
 import InputField from '../components/InputField.vue';
 import DataTable from '../components/DataTable.vue';
 
-const invoiceRows = [
-  ['RE-2024-120', '12.09.2024', 'Bezahlt', '€ 1.250'],
-  ['GS-2024-013', '01.09.2024', 'Offen', '-€ 250']
-];
+type CustomerNote = {
+  id: string;
+  content: string;
+  createdAt: string;
+  author: {
+    id: string;
+    displayName: string;
+  };
+};
+
+type CustomerInvoice = {
+  id: string;
+  number: number;
+  type: 'INVOICE' | 'CREDIT_NOTE';
+  status: 'OPEN' | 'PAID' | 'VOID';
+  issuedAt: string;
+  totalCents: number;
+};
+
+type CustomerDetail = {
+  id: string;
+  name: string;
+  address: string | null;
+  contactPerson: string | null;
+  phone: string | null;
+  notes: CustomerNote[];
+  invoices: CustomerInvoice[];
+};
+
+const route = useRoute();
+const customer = ref<CustomerDetail | null>(null);
+const customerForm = ref({
+  address: '',
+  contactPerson: '',
+  phone: ''
+});
+const isLoading = ref(false);
+
+const latestNote = computed(() => customer.value?.notes?.[0] ?? null);
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR'
+  }).format(value / 100);
+
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat('de-DE').format(new Date(value));
+
+const formatStatus = (status: CustomerInvoice['status']) => {
+  switch (status) {
+    case 'PAID':
+      return 'Bezahlt';
+    case 'VOID':
+      return 'Storniert';
+    default:
+      return 'Offen';
+  }
+};
+
+const formatNumber = (invoice: CustomerInvoice) => {
+  const prefix = invoice.type === 'CREDIT_NOTE' ? 'GS' : 'RE';
+  return `${prefix}-${invoice.number}`;
+};
+
+const invoiceRows = computed(() =>
+  customer.value
+    ? customer.value.invoices.map((invoice) => [
+        formatNumber(invoice),
+        formatDate(invoice.issuedAt),
+        formatStatus(invoice.status),
+        formatCurrency(invoice.totalCents)
+      ])
+    : []
+);
+
+const loadCustomer = async () => {
+  const id = route.params.id;
+  if (typeof id !== 'string') {
+    return;
+  }
+  isLoading.value = true;
+  try {
+    const baseUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+    const response = await fetch(`${baseUrl}/api/customers/${id}`);
+    if (!response.ok) {
+      throw new Error('Customer load failed');
+    }
+    const data: CustomerDetail = await response.json();
+    customer.value = data;
+    customerForm.value = {
+      address: data.address ?? '',
+      contactPerson: data.contactPerson ?? '',
+      phone: data.phone ?? ''
+    };
+  } catch (error) {
+    console.error(error);
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+onMounted(loadCustomer);
 </script>


### PR DESCRIPTION
### Motivation
- Replace hardcoded customer details in the UI with real data from the backend to make the detail page dynamic and editable.
- Provide the customer detail API to return related invoices and notes so the frontend can render the full detail view.
- Allow form inputs to be two-way bound so edited customer fields can be persisted later.

### Description
- Added a new endpoint `GET /api/customers/:id` in `backend/src/server.ts` that returns a customer with `invoices` (ordered by `issuedAt`) and `notes` (ordered by `createdAt` and including `author`).
- Updated `frontend/src/pages/CustomerDetailPage.vue` to fetch the customer by `id`, populate a local `customerForm`, compute `invoiceRows`, display latest note metadata, and show a loading state; several helper formatters were added for dates, currency and status.
- Made `frontend/src/components/InputField.vue` compatible with `v-model` by emitting `update:modelValue` and wiring the input `value` and `@input` handler.

### Testing
- No automated tests were executed as part of this change.
- Local runtime checks were limited to applying patches and committing the changes; no `npm`/`yarn` install, build, or unit/integration test run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698812d2044c832392db77e7bfa661ae)