### PR TITLE
fix(frontend): preserve node_modules in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - "5173:5173"
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     depends_on:
       - backend
 


### PR DESCRIPTION
### Motivation
- The frontend service bind-mounts the project into `/app`, which hides dependencies installed inside the container and produced runtime errors like `failed to resolve import axios`, so the Compose config needed to preserve `node_modules`.

### Description
- Add an anonymous volume mounted at `/app/node_modules` for the `frontend` service in `docker-compose.yml` to prevent the host bind mount from overwriting installed dependencies.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b8d11e688323be5f508da092e2ea)